### PR TITLE
Change Dependabot update schedule from weekly to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "quarterly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "quarterly"


### PR DESCRIPTION
## Summary
Updated the Dependabot configuration to reduce the frequency of automated dependency updates from weekly to quarterly for both npm packages and GitHub Actions.

## Changes
- **npm package updates**: Changed schedule interval from weekly (Saturday) to quarterly
- **GitHub Actions updates**: Changed schedule interval from weekly (Saturday) to quarterly

## Details
This change reduces the overhead of frequent dependency update pull requests while still maintaining regular security and feature updates on a quarterly basis. The `day` field has been removed as it is only applicable to weekly schedules.

https://claude.ai/code/session_013gzEWGAaTvfw12NpULBXU7